### PR TITLE
Refactored collaborators and hyperlinks to external collaborator sites

### DIFF
--- a/src/components/Article.jsx
+++ b/src/components/Article.jsx
@@ -1,7 +1,9 @@
-import { useEffect } from 'react';
+import { Fragment, useEffect } from 'react';
 import { MathJaxContext } from 'better-react-mathjax';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faChevronDown, faChevronUp } from '@fortawesome/free-solid-svg-icons';
+
+import data from '../data/collaborators.json';
 
 export default function Article(props) {
     
@@ -11,6 +13,55 @@ export default function Article(props) {
       window.MathJax.typeset();
     }
   }, [props.isOpen, props.item.abstract]);
+
+  const showCollaborators = () => {
+    const collaborators = getCollaborators();
+
+    if (!collaborators) return;
+
+    const formattedCollaborators = formatCollaboratorsJsx(collaborators);
+    
+    return concatenateCollaboratorsJsx(formattedCollaborators, "Joint with");
+
+  };
+
+  const getCollaborators = () => {
+    return props.item.collaborators
+      .map(id => data.find(collaborator => collaborator.id === id))
+      .filter(Boolean);
+  };
+  
+  const formatCollaboratorsJsx = (collaborators) => {
+    return collaborators.map(collaborator => 
+      collaborator.url 
+        ? <a key={collaborator.id} href={collaborator.url} target="_blank">{collaborator.name}</a> 
+        : collaborator.name
+    );
+  };
+
+  const concatenateCollaboratorsJsx = (formattedCollaborators, initialString) => {
+    if (formattedCollaborators.length == 1) {
+      return (
+        <h4><em>
+          {initialString} {formattedCollaborators[0]}
+        </em></h4>
+      )
+    }
+
+    if (formattedCollaborators.length == 2) {
+      return (
+        <h4><em>
+          {initialString} {formattedCollaborators[0]} and {formattedCollaborators[1]}
+        </em></h4>
+      )
+    }
+
+    return (
+      <h4><em>
+        Joint with {formattedCollaborators.slice(0, -1).map((item, i) => <Fragment key={i}>{item}, </Fragment>)} and {formattedCollaborators[formattedCollaborators.length - 1]}
+      </em></h4>
+    )
+  }
 
   return (
     <div className="article-container" key={props.item.id}>
@@ -45,8 +96,11 @@ export default function Article(props) {
           </div>
         </div>
         <div className="article-bottom">
-          <div className="article-details">
+          {/* <div className="article-details">
             {props.item.collaborators && <h4><em>Joint with {props.item.collaborators}</em></h4>}
+          </div> */}
+          <div className="article-details">
+            {props.item.collaborators && showCollaborators()}
           </div>
           {props.isOpen &&
             <div className="article-abstract-container">

--- a/src/data/collaborators.json
+++ b/src/data/collaborators.json
@@ -1,0 +1,22 @@
+[
+  {
+    "id": 0,
+    "name": "Augustinas Jacovskis",
+    "url": "https://ajacovskis.github.io/"
+  },
+  {
+    "id": 1,
+    "name": "Franco Rota",
+    "url": ""
+  },
+  {
+    "id": 2,
+    "name": "Edmund Heng",
+    "url": ""
+  },
+  {
+    "id": 3,
+    "name": "Anthony Licata",
+    "url": ""
+  }
+]

--- a/src/data/research.json
+++ b/src/data/research.json
@@ -20,7 +20,7 @@
     "date": "2023-10-20",
     "showYear": true,
     "abstract": "<div>We studied derived categories of cyclic covers, and the question of whether such a cover can be recovered (up to isomorphism) from its Kuznetsov component.</div>",
-    "collaborators": "Augustinas Jacovskis and Franco Rota",
+    "collaborators": [0, 1],
     "journalStatus": "Submitted",
     "journalUrl": "",
     "pinned": true
@@ -33,7 +33,7 @@
     "date": "2023-11-12",
     "showYear": true,
     "abstract": "<div>We investigated how stability conditions behave under actions of fusion categories (=<em>tensor categories with extra structure</em>). A crucial example is that, if a finite group \\(G\\) acts on a category \\(\\mathcal{D}\\), then the corresponding \\(G\\)-equivariant category \\(\\mathcal{D}^G\\) is a module category over \\(\\mathrm{rep}(G)\\) (which is a fusion category). As an application, we generalise results from <a href=\"https://arxiv.org/abs/2307.00815\">my first project</a> to non abelian groups.</div>",
-    "collaborators": "Edmund Heng and Anthony Licata",
+    "collaborators": [2, 3],
     "journalStatus": "Submitted",
     "journalUrl": "",
     "pinned": true


### PR DESCRIPTION
Collaborator information is now in the collaborators.json file, which allows information about collaborators to be updated easily. This includes external hyperlinks to their own websites, which display on their names under research article information.